### PR TITLE
Allow use of the fallback loading solution

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -613,7 +613,7 @@ module AnnotateModels
     # Retrieve loaded model class by path to the file where it's supposed to be defined.
     def get_loaded_model(model_path)
       ActiveSupport::Inflector.constantize(ActiveSupport::Inflector.camelize(model_path))
-    rescue
+    rescue StandardError, LoadError
       # Revert to the old way but it is not really robust
       ObjectSpace.each_object(::Class)
                  .select do |c|


### PR DESCRIPTION
LoadError is the critical one to rescue here, but it does not descend from `StandardError` so the fallback loading is never invoked.
```
>> LoadError.ancestors
=> [LoadError, ScriptError, Exception, Object, Kernel, BasicObject]
```

### BEFORE THIS FIX:
```
$ bundle exec annotate
D, [2017-06-02T13:02:41.484425 #16758] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.2ms)  SELECT `schema_migrations`.* FROM `schema_migrations` /*application:Tophatter*/
/Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:495:in `load_missing_constant': Unable to autoload constant CsvRequest, expected /Users/pboling/Documents/tophatter/app/models/csv_request.rb to define it (LoadError)
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:184:in `const_missing'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/inflector/methods.rb:261:in `const_get'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/inflector/methods.rb:261:in `block in constantize'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/inflector/methods.rb:259:in `each'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/inflector/methods.rb:259:in `inject'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/activesupport-4.2.7.1/lib/active_support/inflector/methods.rb:259:in `constantize'
	from /Users/pboling/.rvm/gems/ruby-2.2.6/gems/annotate-2.7.2/lib/annotate/annotate_models.rb:615:in `get_loaded_model'
```

### After this fix:
```
$ bundle exec annotate
Annotated (###): app/models/...
```
then
```
$ bundle exec annotate
Model files unchanged.
```